### PR TITLE
Add the ability to replay recent messages upon new connection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,9 @@
 test:
 	go test -v -count=1 ./...
 
+# test one thing
+t1:
+	go test -timeout 30s -v -count=1 -run ^$(test)$$ ./grav
+
 deps:
 	go get -u -d ./...

--- a/grav/bus.go
+++ b/grav/bus.go
@@ -1,10 +1,10 @@
 package grav
 
 const (
-	defaultBusChanSize = 512
+	defaultBusChanSize = 256
 )
 
-// messageBus is responsible for emitting events among the connected pods
+// messageBus is responsible for emitting messages among the connected pods
 // and managing the failure cases for those pods
 type messageBus struct {
 	busChan MsgChan

--- a/grav/bus.go
+++ b/grav/bus.go
@@ -1,17 +1,23 @@
 package grav
 
+const (
+	defaultBusChanSize = 512
+)
+
 // messageBus is responsible for emitting events among the connected pods
 // and managing the failure cases for those pods
 type messageBus struct {
 	busChan MsgChan
 	pool    *connectionPool
+	buffer  *msgBuffer
 }
 
 // newMessageBus creates a new messageBus
 func newMessageBus() *messageBus {
 	b := &messageBus{
-		busChan: make(chan Message, 256),
+		busChan: make(chan Message, defaultBusChanSize),
 		pool:    newConnectionPool(),
+		buffer:  newMsgBuffer(defaultBufferSize),
 	}
 
 	b.start()
@@ -33,8 +39,8 @@ func (b *messageBus) start() {
 		// ring, and repeat forever when each new message arrives
 		for msg := range b.busChan {
 			for {
-				// make sure the pod we start with is healthy
-				if err := b.pool.checkNextPod(); err == nil {
+				// make sure the next pod is ready for messages
+				if err := b.pool.prepareNext(b.buffer); err == nil {
 					break
 				}
 			}
@@ -42,6 +48,8 @@ func (b *messageBus) start() {
 			startingConn := b.pool.next()
 
 			b.traverse(msg, startingConn)
+
+			b.buffer.Push(msg)
 		}
 	}()
 }
@@ -55,7 +63,7 @@ func (b *messageBus) traverse(msg Message, start *podConnection) {
 		conn.send(msg)
 
 		next := b.pool.peek()
-		if err := b.pool.checkNextPod(); err != nil {
+		if err := b.pool.prepareNext(b.buffer); err != nil {
 			if startID == next.ID {
 				startID = next.next.ID
 			}

--- a/grav/message.go
+++ b/grav/message.go
@@ -11,7 +11,8 @@ import (
 
 // MsgTypeDefault and other represent message consts
 const (
-	MsgTypeDefault string = "grav.default"
+	MsgTypeDefault     string = "grav.default"
+	msgTypePodFeedback string = "grav.feedback"
 )
 
 // MsgFunc is a callback function that accepts a message and returns an error

--- a/grav/msgbuffer.go
+++ b/grav/msgbuffer.go
@@ -1,0 +1,86 @@
+package grav
+
+import (
+	"sync"
+)
+
+const (
+	defaultBufferSize = 128
+)
+
+// msgBuffer is a buffer of messages with a particular size limit.
+// Oldest messages are automatically evicted as new ones are added
+// past said limit. Push() and Iter() are thread-safe.
+type msgBuffer struct {
+	msgs       map[string]Message
+	order      []string
+	limit      int
+	startIndex int
+	lock       sync.RWMutex
+}
+
+func newMsgBuffer(limit int) *msgBuffer {
+	m := &msgBuffer{
+		msgs:       map[string]Message{},
+		order:      []string{},
+		limit:      limit,
+		startIndex: 0,
+		lock:       sync.RWMutex{},
+	}
+
+	return m
+}
+
+// Push pushes a new message onto the end of the buffer and evicts the oldest, if needed (based on limit)
+func (m *msgBuffer) Push(msg Message) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	m.msgs[msg.UUID()] = msg
+
+	lastIndex := len(m.order) - 1
+
+	if len(m.order) == m.limit {
+		delete(m.msgs, m.order[m.startIndex]) // delete the current "first"
+
+		m.order[m.startIndex] = msg.UUID()
+
+		if m.startIndex == lastIndex {
+			m.startIndex = 0
+		} else {
+			m.startIndex++
+		}
+	} else {
+		m.order = append(m.order, msg.UUID())
+	}
+}
+
+// Iter calls msgFunc once per message in the buffer
+func (m *msgBuffer) Iter(msgFunc MsgFunc) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	index := m.startIndex
+	lastIndex := len(m.order) - 1
+
+	more := true
+	for more {
+		uuid := m.order[index]
+		msg := m.msgs[uuid]
+
+		msgFunc(msg)
+
+		newIndex := index
+		if newIndex == lastIndex {
+			newIndex = 0
+		} else {
+			newIndex++
+		}
+
+		if newIndex == m.startIndex {
+			more = false
+		}
+
+		index = newIndex
+	}
+}

--- a/grav/pod.go
+++ b/grav/pod.go
@@ -6,7 +6,13 @@ import (
 )
 
 const (
+	// defaultPodChanSize is the default size of the channels used for pod - bus communication
 	defaultPodChanSize = 128
+)
+
+var (
+	// podFeedbackMsgReplay is the message sent via feedback channel when message replay is desired
+	podFeedbackMsgReplay = NewMsg(msgTypePodFeedback, []byte{})
 )
 
 /**
@@ -31,23 +37,30 @@ Created with Monodraw
 type Pod struct {
 	onFunc MsgFunc // the onFunc is called whenever a message is recieved
 
-	messageChan MsgChan // messageChan is used to recieve messages coming from the bus
-	errorChan   MsgChan // errorChan is used to send failed messages back to the bus
-	busChan     MsgChan // busChan is used to emit messages to the bus
+	messageChan  MsgChan // messageChan is used to recieve messages coming from the bus
+	feedbackChan MsgChan // feedbackChan is used to send "feedback" to the bus about the pod's status
+	busChan      MsgChan // busChan is used to emit messages to the bus
 
 	*messageFilter // the embedded messageFilter controls which messages reach the onFunc
+
+	opts *podOpts
 
 	dead bool
 	sync.RWMutex
 }
 
+type podOpts struct {
+	WantsReplay bool
+}
+
 // newPod creates a new Pod
-func newPod(group string, busChan MsgChan) *Pod {
+func newPod(busChan MsgChan, opts *podOpts) *Pod {
 	p := &Pod{
 		messageChan:   make(chan Message, defaultPodChanSize),
-		errorChan:     make(chan Message, defaultPodChanSize),
+		feedbackChan:  make(chan Message, defaultPodChanSize),
 		busChan:       busChan,
 		messageFilter: newMessageFilter(),
+		opts:          opts,
 		dead:          false,
 		RWMutex:       sync.RWMutex{},
 	}
@@ -66,7 +79,7 @@ func (p *Pod) On(onFunc MsgFunc) {
 	// reset the message filter when the onFunc is changed
 	p.messageFilter = newMessageFilter()
 
-	p.onFunc = onFunc
+	p.setOnFunc(onFunc)
 }
 
 // OnType sets the function to be called whenever this pod recieves a message and sets the pod's filter to only include certain message types
@@ -82,7 +95,7 @@ func (p *Pod) OnType(onFunc MsgFunc, msgTypes ...string) {
 		p.FilterType(t, true)
 	}
 
-	p.onFunc = onFunc
+	p.setOnFunc(onFunc)
 }
 
 // ErrMsgNotWanted is used by WaitOn to determine if the current message is what's being waited on
@@ -96,13 +109,13 @@ func (p *Pod) WaitOn(onFunc MsgFunc) error {
 	p.Lock()
 	errChan := make(chan error)
 
-	p.onFunc = func(msg Message) error {
+	p.setOnFunc(func(msg Message) error {
 		if err := onFunc(msg); err != ErrMsgNotWanted {
 			errChan <- err
 		}
 
 		return nil
-	}
+	})
 	p.Unlock() // can't stay locked here or the onFunc will never be called
 
 	err := <-errChan
@@ -110,7 +123,7 @@ func (p *Pod) WaitOn(onFunc MsgFunc) error {
 	p.Lock()
 	defer p.Unlock()
 
-	p.onFunc = nil
+	p.setOnFunc(nil)
 
 	return err
 }
@@ -124,16 +137,26 @@ func (p *Pod) Send(msg Message) {
 		return
 	}
 
-	go func() {
-		p.FilterUUID(msg.UUID(), false) // don't allow the same message to bounce back through this pod
+	p.FilterUUID(msg.UUID(), false) // don't allow the same message to bounce back through this pod
 
-		p.busChan <- msg
-	}()
+	p.busChan <- msg
 }
 
-// busChans returns the messageChan and errorChan to be used by the bus
+// setOnFunc sets the OnFunc. THIS DOES NOT LOCK. THE CALLER MUST LOCK.
+func (p *Pod) setOnFunc(on MsgFunc) {
+	p.onFunc = on
+
+	if on != nil {
+		if p.opts.WantsReplay {
+			p.feedbackChan <- podFeedbackMsgReplay
+			p.opts.WantsReplay = false
+		}
+	}
+}
+
+// busChans returns the messageChan and feedbackChan to be used by the bus
 func (p *Pod) busChans() (MsgChan, MsgChan) {
-	return p.messageChan, p.errorChan
+	return p.messageChan, p.feedbackChan
 }
 
 func (p *Pod) start() {
@@ -146,10 +169,10 @@ func (p *Pod) start() {
 			if p.onFunc != nil && p.allow(msg) {
 				if err := p.onFunc(msg); err != nil {
 					// if the onFunc failed, send it back to the bus to be re-sent later
-					p.errorChan <- msg
+					p.feedbackChan <- msg
 				} else {
 					// if it was successful, a nil on the channel lets the conn know all is well
-					p.errorChan <- nil
+					p.feedbackChan <- nil
 				}
 			}
 

--- a/grav/pod_test.go
+++ b/grav/pod_test.go
@@ -4,22 +4,19 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
+
+	"github.com/suborbital/grav/testutil"
 )
 
 func TestPodFilter(t *testing.T) {
 	g := New()
 
-	lock := sync.Mutex{}
-	count := 0
+	counter := testutil.NewAsyncCounter(100)
 
 	onFunc := func(msg Message) error {
-		lock.Lock()
-		defer lock.Unlock()
-
-		count++
+		counter.Count()
 
 		return nil
 	}
@@ -34,12 +31,10 @@ func TestPodFilter(t *testing.T) {
 		p1.Send(NewMsg(MsgTypeDefault, []byte(fmt.Sprintf("hello, world %d", i))))
 	}
 
-	time.Sleep(time.Duration(time.Second))
-
 	// only 10 should be tracked because p1 should have filtered out the messages that it sent
 	// and then they should not reach its own onFunc
-	if count != 10 {
-		t.Errorf("incorrect number of messages, expected 10, got %d", count)
+	if err := counter.Wait(10, 1); err != nil {
+		t.Error(err)
 	}
 }
 
@@ -85,12 +80,12 @@ const msgTypeBad = "test.bad"
 func TestPodFailure(t *testing.T) {
 	g := New()
 
-	counter := make(chan bool, 1000)
+	counter := testutil.NewAsyncCounter(200)
 
 	// create one pod that returns errors on "bad" messages
 	p := g.Connect()
 	p.On(func(msg Message) error {
-		counter <- true
+		counter.Count()
 
 		if msg.Type() == msgTypeBad {
 			return errors.New("bad message")
@@ -104,7 +99,7 @@ func TestPodFailure(t *testing.T) {
 		p2 := g.Connect()
 
 		p2.On(func(msg Message) error {
-			counter <- true
+			counter.Count()
 
 			return nil
 		})
@@ -117,32 +112,19 @@ func TestPodFailure(t *testing.T) {
 		pod.Send(NewMsg(msgTypeBad, []byte(fmt.Sprintf("hello, world %d", i))))
 	}
 
-	time.Sleep(time.Duration(time.Second))
+	time.Sleep(time.Second)
 
 	// send 10 more "bad" messages
 	for i := 0; i < 10; i++ {
 		pod.Send(NewMsg(msgTypeBad, []byte(fmt.Sprintf("hello, world %d", i))))
 	}
 
-	time.Sleep(time.Duration(time.Second))
-
-	count := 0
-	more := true
-	for more {
-		select {
-		case <-counter:
-			count++
-		default:
-			more = false
-		}
-	}
-
 	// 730 because the 64th message to the "bad" pod put it over the highwater
 	// mark and so the last 10 message would never be delievered
 	// sleeps were needed to allow all of the internal goroutines to finish execing
 	// in the worst case scenario of a single process machine (which lots of containers are)
-	if count != 730 {
-		t.Errorf("incorrect number of messages, expected 730, got %d", count)
+	if err := counter.Wait(730, 1); err != nil {
+		t.Error(err)
 	}
 
 	// the first pod should now have been disconnected, causing only 9 recievers reset and test again
@@ -152,36 +134,22 @@ func TestPodFailure(t *testing.T) {
 		pod.Send(NewMsg(MsgTypeDefault, []byte(fmt.Sprintf("hello, world %d", i))))
 	}
 
-	time.Sleep(time.Duration(time.Second))
-
-	count = 0
-	more = true
-	for more {
-		select {
-		case <-counter:
-			count++
-		default:
-			more = false
-		}
-	}
-
-	if count != 90 {
-		t.Errorf("incorrect number of messages, expected 90, got %d", count)
+	if err := counter.Wait(90, 1); err != nil {
+		t.Error(err)
 	}
 }
 
-func TestPodFailurePart2(t *testing.T) {
+func TestPodFailurePt2(t *testing.T) {
 	// test where the "bad" pod is somewhere in the "middle" of the ring
 	g := New()
 
-	counter := make(chan bool, 1000)
+	counter := testutil.NewAsyncCounter(200)
 
-	// and another 9 that don't
 	for i := 0; i < 4; i++ {
 		p2 := g.Connect()
 
 		p2.On(func(msg Message) error {
-			counter <- true
+			counter.Count()
 
 			return nil
 		})
@@ -190,7 +158,7 @@ func TestPodFailurePart2(t *testing.T) {
 	// create one pod that returns errors on "bad" messages
 	p := g.Connect()
 	p.On(func(msg Message) error {
-		counter <- true
+		counter.Count()
 
 		if msg.Type() == msgTypeBad {
 			return errors.New("bad message")
@@ -204,7 +172,7 @@ func TestPodFailurePart2(t *testing.T) {
 		p2 := g.Connect()
 
 		p2.On(func(msg Message) error {
-			counter <- true
+			counter.Count()
 
 			return nil
 		})
@@ -224,25 +192,12 @@ func TestPodFailurePart2(t *testing.T) {
 		pod.Send(NewMsg(msgTypeBad, []byte(fmt.Sprintf("hello, world %d", i))))
 	}
 
-	time.Sleep(time.Duration(time.Second))
-
-	count := 0
-	more := true
-	for more {
-		select {
-		case <-counter:
-			count++
-		default:
-			more = false
-		}
-	}
-
 	// 730 because the 64th message to the "bad" pod put it over the highwater
 	// mark and so the last 10 message would never be delievered
 	// sleeps were needed to allow all of the internal goroutines to finish execing
 	// in the worst case scenario of a single process machine (which lots of containers are)
-	if count != 730 {
-		t.Errorf("incorrect number of messages, expected 730, got %d", count)
+	if err := counter.Wait(730, 1); err != nil {
+		t.Error(err)
 	}
 
 	// the first pod should now have been disconnected, causing only 9 recievers reset and test again
@@ -252,33 +207,20 @@ func TestPodFailurePart2(t *testing.T) {
 		pod.Send(NewMsg(MsgTypeDefault, []byte(fmt.Sprintf("hello, world %d", i))))
 	}
 
-	time.Sleep(time.Duration(time.Second))
-
-	count = 0
-	more = true
-	for more {
-		select {
-		case <-counter:
-			count++
-		default:
-			more = false
-		}
-	}
-
-	if count != 90 {
-		t.Errorf("incorrect number of messages, expected 90, got %d", count)
+	if err := counter.Wait(90, 1); err != nil {
+		t.Error(err)
 	}
 }
 
 func TestPodFlushFailed(t *testing.T) {
 	g := New()
 
-	counter := make(chan bool, 100)
+	counter := testutil.NewAsyncCounter(200)
 
 	// create a pod that returns errors on "bad" messages
 	p := g.Connect()
 	p.On(func(msg Message) error {
-		counter <- true
+		counter.Count()
 
 		if msg.Type() == msgTypeBad {
 			return errors.New("bad message")
@@ -287,56 +229,48 @@ func TestPodFlushFailed(t *testing.T) {
 		return nil
 	})
 
-	pod := g.Connect()
+	sender := g.Connect()
 
 	// send 5 "bad" messages
 	for i := 0; i < 5; i++ {
-		pod.Send(NewMsg(msgTypeBad, []byte(fmt.Sprintf("hello, world %d", i))))
+		sender.Send(NewMsg(msgTypeBad, []byte(fmt.Sprintf("hello, world %d", i))))
 	}
 
-	time.Sleep(time.Duration(time.Second))
+	<-time.After(time.Duration(time.Second))
 
 	// replace the OnFunc to not error when the flushed messages come back through
 	p.On(func(msg Message) error {
-		counter <- true
+		counter.Count()
 
 		return nil
 	})
 
 	// send 10 "normal" messages
-	for i := 0; i < 10; i++ {
-		pod.Send(NewMsg(MsgTypeDefault, []byte(fmt.Sprintf("hello, world %d", i))))
+	for i := 0; i < 9; i++ {
+		sender.Send(NewMsg(MsgTypeDefault, []byte(fmt.Sprintf("hello, world %d", i))))
 	}
 
-	time.Sleep(time.Duration(time.Second))
+	<-time.After(time.Duration(time.Second))
 
-	count := 0
-	more := true
-	for more {
-		select {
-		case <-counter:
-			count++
-		default:
-			more = false
-		}
-	}
+	// yes this is stupid, but on single-CPU machines (such as GitHub actions), this test won't allow things to be flushed properly.
+	sender.Send(NewMsg(MsgTypeDefault, []byte(fmt.Sprintf("flushing!"))))
 
 	// 20 because upon handling the first "good" message, the bus should flush
 	// the 5 "failed" messages back into the connection thus repeating them
-	if count != 20 {
-		t.Errorf("incorrect number of messages, expected 20, got %d", count)
+	if err := counter.Wait(20, 1); err != nil {
+		t.Error(err)
 	}
 }
 
 func TestPodReplay(t *testing.T) {
 	g := New()
 
-	counter := make(chan bool, 1000)
+	counter := testutil.NewAsyncCounter(500)
 
 	// create one pod that returns errors on "bad" messages
 	p1 := g.Connect()
 	p1.On(func(msg Message) error {
-		counter <- true
+		counter.Count()
 		return nil
 	})
 
@@ -347,113 +281,56 @@ func TestPodReplay(t *testing.T) {
 		sender.Send(NewMsg(MsgTypeDefault, []byte(fmt.Sprintf("hello, world %d", i))))
 	}
 
-	time.Sleep(time.Duration(time.Second))
-
-	count := 0
-	more := true
-	for more {
-		select {
-		case <-counter:
-			count++
-		default:
-			more = false
-		}
-	}
-
-	if count != 100 {
-		t.Errorf("p1 did not receive 100 initial messages, got %d", count)
+	if err := counter.Wait(100, 1); err != nil {
+		t.Error(err)
 	}
 
 	// connect a second pod with replay to ensure the same messages come through
 	p2 := g.ConnectWithReplay()
 	p2.On(func(msg Message) error {
-		counter <- true
+		counter.Count()
 		return nil
 	})
 
 	sender.Send(NewMsg(MsgTypeDefault, []byte("let's get it started")))
 
-	time.Sleep(time.Duration(time.Second))
-
-	count = 0
-	more = true
-	for more {
-		select {
-		case <-counter:
-			count++
-		default:
-			more = false
-		}
-	}
-
-	// 102 because p1 and p2 each got the new message, and p2 replayed the original 100
-	if count != 102 {
-		t.Errorf("incorrect number of messages, expected 102, got %d", count)
+	if err := counter.Wait(102, 1); err != nil {
+		t.Error(err)
 	}
 }
 
 func TestPodReplayPt2(t *testing.T) {
 	g := New()
 
-	counter := make(chan bool, 1000)
+	counter := testutil.NewAsyncCounter(2000)
 
-	// create one pod that returns errors on "bad" messages
 	p1 := g.Connect()
 	p1.On(func(msg Message) error {
-		counter <- true
+		counter.Count()
 		return nil
 	})
 
 	sender := g.Connect()
 
-	// send 100 messages and ensure they're received by p1
+	// send 1000 messages and ensure they're received by p1
 	for i := 0; i < 1000; i++ {
-		j := i
-		sender.Send(NewMsg(MsgTypeDefault, []byte(fmt.Sprintf("hello, world %d", j))))
+		sender.Send(NewMsg(MsgTypeDefault, []byte(fmt.Sprintf("hello, world %d", i))))
 	}
 
-	time.Sleep(time.Duration(time.Second))
-
-	count := 0
-	more := true
-	for more {
-		select {
-		case <-counter:
-			count++
-		default:
-			more = false
-		}
-	}
-
-	if count != 1000 {
-		t.Errorf("p1 did not receive 1000 initial messages, got %d", count)
+	if err := counter.Wait(1000, 1); err != nil {
+		t.Error(err)
 	}
 
 	// connect a second pod with replay to ensure the same messages come through
 	p2 := g.ConnectWithReplay()
 	p2.On(func(msg Message) error {
-		fmt.Println(string(msg.Data()))
-		counter <- true
+		counter.Count()
 		return nil
 	})
 
-	sender.Send(NewMsg(MsgTypeDefault, []byte("let's get it started")))
+	sender.Send(NewMsg(MsgTypeDefault, []byte(fmt.Sprintf("let's get started"))))
 
-	time.Sleep(time.Duration(time.Second))
-
-	count = 0
-	more = true
-	for more {
-		select {
-		case <-counter:
-			count++
-		default:
-			more = false
-		}
-	}
-
-	// 130 because p1 and p2 each got the new message, and p2 replayed the 128 in the bus' buffer
-	if count != 130 {
-		t.Errorf("incorrect number of messages, expected 130, got %d", count)
+	if err := counter.Wait(130, 1); err != nil {
+		t.Error(err)
 	}
 }

--- a/testutil/asynccoutner.go
+++ b/testutil/asynccoutner.go
@@ -1,0 +1,53 @@
+package testutil
+
+import (
+	"fmt"
+	"time"
+)
+
+// AsyncCounter is an async counter
+type AsyncCounter struct {
+	countChan chan bool
+}
+
+// NewAsyncCounter creates a new AsyncCounter
+func NewAsyncCounter(size int) *AsyncCounter {
+	t := &AsyncCounter{
+		countChan: make(chan bool, size),
+	}
+
+	return t
+}
+
+// Count increments the counter
+func (a *AsyncCounter) Count() {
+	go func() {
+		a.countChan <- true
+	}()
+}
+
+// Wait waits until the total is reached or the timeout happens
+func (a *AsyncCounter) Wait(total, timeoutSeconds int) error {
+	count := 0
+	timeoutMs := int64(timeoutSeconds * 1000)
+	start := time.Now()
+
+	for {
+		select {
+		case <-a.countChan:
+			count++
+		default:
+			// nothing
+		}
+
+		if time.Since(start).Milliseconds() > timeoutMs {
+			break
+		}
+	}
+
+	if count != total {
+		return fmt.Errorf("AsyncCoutnter got the incorrect count: %d, expected %d (in %d seconds)", count, total, timeoutSeconds)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR adds a message buffer (owned by the bus) which keeps the most recent {number} of messages handy.

The Grav object grows a new `ConnectWithReplay` method which allows the new pod to have the buffer replayed onto it as soon as its `OnFunc` is set. 

This is accomplished by changing the `errChan` on the pod/podConnection to instead be a `feedbackChan` which allows for more dynamic status to be communicated with the bus about the state of the pod.

When the Pod's OnFunc is set for the first time and the `WantsReplay` option is true on its options object, the pod will send a message on the feedback chan. When the bus performs `prepareNext` during traversal, it detects that particular message and then replays the current buffer into that conn before sending the new message.