### PR TITLE
Add basic request/reply mechanics

### DIFF
--- a/grav/msgbuffer.go
+++ b/grav/msgbuffer.go
@@ -60,6 +60,10 @@ func (m *msgBuffer) Iter(msgFunc MsgFunc) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 
+	if len(m.order) == 0 {
+		return
+	}
+
 	index := m.startIndex
 	lastIndex := len(m.order) - 1
 

--- a/grav/pod.go
+++ b/grav/pod.go
@@ -159,7 +159,7 @@ func (p *Pod) WaitOn(onFunc MsgFunc, timeoutSeconds ...int) error {
 
 	p.onFuncLock.Unlock() // can't stay locked here or the onFunc will never be called
 
-	timeout := 10
+	timeout := 3
 	if timeoutSeconds != nil {
 		timeout = timeoutSeconds[0]
 	}

--- a/grav/pod.go
+++ b/grav/pod.go
@@ -187,7 +187,7 @@ func (p *Pod) WaitOn(onFunc MsgFunc, timeoutSeconds ...int) error {
 func (p *Pod) WaitOnReply(ticket MessageTicket, onFunc MsgFunc, timeoutSeconds ...int) error {
 	var reply Message
 
-	p.WaitOn(func(msg Message) error {
+	if err := p.WaitOn(func(msg Message) error {
 		if msg.ReplyTo() != ticket.UUID {
 			return ErrMsgNotWanted
 		}
@@ -195,7 +195,9 @@ func (p *Pod) WaitOnReply(ticket MessageTicket, onFunc MsgFunc, timeoutSeconds .
 		reply = msg
 
 		return nil
-	}, timeoutSeconds...)
+	}, timeoutSeconds...); err != nil {
+		return err
+	}
 
 	return onFunc(reply)
 }

--- a/grav/pod.go
+++ b/grav/pod.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 const (
@@ -97,12 +98,12 @@ func (p *Pod) ReplyTo(ticket MessageTicket, msg Message) {
 }
 
 // SendAndWaitOnReply sends a message and then blocks until a message is recieved in ReplyTo that message
-func (p *Pod) SendAndWaitOnReply(msg Message, onFunc MsgFunc) error {
+func (p *Pod) SendAndWaitOnReply(msg Message, onFunc MsgFunc, timeoutSeconds ...int) error {
 	ticket := msg.Ticket()
 
 	p.Send(msg)
 
-	return p.WaitOnReply(ticket, onFunc)
+	return p.WaitOnReply(ticket, onFunc, timeoutSeconds...)
 }
 
 // On sets the function to be called whenever this pod recieves a message from the bus. If nil is passed, the pod will ignore all messages.
@@ -136,11 +137,15 @@ func (p *Pod) OnType(onFunc MsgFunc, msgTypes ...string) {
 // ErrMsgNotWanted is used by WaitOn to determine if the current message is what's being waited on
 var ErrMsgNotWanted = errors.New("message not wanted")
 
+// ErrWaitTimeout is returned if a timeout is exceeded
+var ErrWaitTimeout = errors.New("waited past timeout")
+
 // WaitOn takes a function to be called whenever this pod recieves a message and blocks until that function returns
 // something other than ErrMsgNotWanted. WaitOn should be used if there is a need to wait for a particular message.
 // When the onFunc returns something other than ErrMsgNotWanted (such as nil or a different error), WaitOn will return and set
 // the onFunc to nil. If an error other than ErrMsgNotWanted is returned from the onFunc, it will be propogated to the caller.
-func (p *Pod) WaitOn(onFunc MsgFunc) error {
+// An optional timeout (default 10s) can be provided (only the first value will be used). If the timeout is exceeded, ErrWaitTimeout is returned.
+func (p *Pod) WaitOn(onFunc MsgFunc, timeoutSeconds ...int) error {
 	p.onFuncLock.Lock()
 	errChan := make(chan error)
 
@@ -154,19 +159,32 @@ func (p *Pod) WaitOn(onFunc MsgFunc) error {
 
 	p.onFuncLock.Unlock() // can't stay locked here or the onFunc will never be called
 
-	err := <-errChan
+	timeout := 10
+	if timeoutSeconds != nil {
+		timeout = timeoutSeconds[0]
+	}
+
+	var onFuncErr error
+
+	select {
+	case err := <-errChan:
+		onFuncErr = err
+	case <-time.After(time.Second * time.Duration(timeout)):
+		onFuncErr = ErrWaitTimeout
+	}
 
 	p.onFuncLock.Lock()
 	defer p.onFuncLock.Unlock()
 
 	p.setOnFunc(nil)
 
-	return err
+	return onFuncErr
 }
 
 // WaitOnReply waits on a reply message to arrive at the pod and then calls onFunc with that message.
 // If the onFunc produces an error, it will be propogated to the caller.
-func (p *Pod) WaitOnReply(ticket MessageTicket, onFunc MsgFunc) error {
+// an optionsl timrout can be provided (only the first value will be used)
+func (p *Pod) WaitOnReply(ticket MessageTicket, onFunc MsgFunc, timeoutSeconds ...int) error {
 	var reply Message
 
 	p.WaitOn(func(msg Message) error {
@@ -177,7 +195,7 @@ func (p *Pod) WaitOnReply(ticket MessageTicket, onFunc MsgFunc) error {
 		reply = msg
 
 		return nil
-	})
+	}, timeoutSeconds...)
 
 	return onFunc(reply)
 }

--- a/grav/reqreply_test.go
+++ b/grav/reqreply_test.go
@@ -1,0 +1,67 @@
+package grav
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/suborbital/grav/testutil"
+)
+
+func TestRequestReply(t *testing.T) {
+	g := New()
+	p1 := g.Connect()
+
+	msg := NewMsg(MsgTypeDefault, []byte("joey"))
+	p1.Send(msg)
+
+	p2 := g.ConnectWithReplay()
+	p2.On(func(msg Message) error {
+		data := string(msg.Data())
+
+		reply := NewMsg(MsgTypeDefault, []byte(fmt.Sprintf("hey %s", data)))
+		p2.ReplyTo(msg.Ticket(), reply)
+
+		return nil
+	})
+
+	counter := testutil.NewAsyncCounter(10)
+
+	go func() {
+		p1.WaitOnReply(msg.Ticket(), func(msg Message) error {
+			if string(msg.Data()) == "hey joey" {
+				counter.Count()
+			}
+
+			return nil
+		})
+	}()
+
+	counter.Wait(1, 1)
+}
+
+func TestRequestReplySugar(t *testing.T) {
+	g := New()
+	p1 := g.Connect()
+
+	counter := testutil.NewAsyncCounter(10)
+
+	go func() {
+		msg := NewMsg(MsgTypeDefault, []byte("joey"))
+		p1.SendAndWaitOnReply(msg, func(msg Message) error {
+			counter.Count()
+			return nil
+		})
+	}()
+
+	p2 := g.ConnectWithReplay()
+	p2.On(func(msg Message) error {
+		data := string(msg.Data())
+
+		reply := NewMsg(MsgTypeDefault, []byte(fmt.Sprintf("hey %s", data)))
+		p2.ReplyTo(msg.Ticket(), reply)
+
+		return nil
+	})
+
+	counter.Wait(1, 1)
+}

--- a/grav/reqreply_test.go
+++ b/grav/reqreply_test.go
@@ -65,3 +65,21 @@ func TestRequestReplySugar(t *testing.T) {
 
 	counter.Wait(1, 1)
 }
+
+func TestRequestReplyTimeout(t *testing.T) {
+	g := New()
+	p1 := g.Connect()
+
+	counter := testutil.NewAsyncCounter(10)
+
+	go func() {
+		msg := NewMsg(MsgTypeDefault, []byte("joey"))
+		if err := p1.SendAndWaitOnReply(msg, func(msg Message) error {
+			return nil
+		}, 1); err == ErrWaitTimeout {
+			counter.Count()
+		}
+	}()
+
+	counter.Wait(1, 2)
+}


### PR DESCRIPTION
This adds some basic capabilities for "replying" to a message. The `ReplyTo` method on the message interface returns a UUID if the message in question is a reply to another message. Some sugar methods have been added to `Pod` to help facilitate replies. The `MessageTicket` type is added to act as a reference to a message that the caller may want a reply to.

`ReplyTo` sends a reply to a given message
`WaitOnReply` blocks until a reply is received for a given message
`SendAndWaitOnReply` combines `Send` and `WaitOnReply`. I hope that was obvious.

`WaitOn`, `WaitOnReply`, and `SendAndWaitOnReply` all take an optional timeout (the param is `...int` but only the first one is respected). If no timeout is given, it defaults to 3s.

See `reqreply_test.go` for an example.