### PR TITLE
Add ability to withdraw from mesh

### DIFF
--- a/transport/http/transport.go
+++ b/transport/http/transport.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -171,7 +172,7 @@ func (t *Transport) handleRequest(req *http.Request) (interface{}, error) {
 }
 
 // Start "starts" the connection
-func (e *Endpoint) Start(recvFunc grav.ReceiveFunc) {
+func (e *Endpoint) Start(recvFunc grav.ReceiveFunc, ctx context.Context) {
 	e.receiveFunc = recvFunc
 }
 


### PR DESCRIPTION
This PR allows a grav node to 'withdraw' from the mesh.

Withdrawn nodes can still send messages, but will not recieve.

Withdrawing is now the first step when Grav's context is canceled, and a 5s delay was added to allow the node to handle received messages before properly closing its connections and exiting.