### PR TITLE
fix(transport): fall back to raw data when incoming message is not in expected format

### DIFF
--- a/transport/kafka/tester/main.go
+++ b/transport/kafka/tester/main.go
@@ -24,11 +24,11 @@ func main() {
 		grav.UseTransport(knats),
 	)
 
-	if err := g.ConnectBridgeTopic(grav.MsgTypeDefault); err != nil {
+	if err := g.ConnectBridgeTopic("something.in"); err != nil {
 		log.Fatal(errors.Wrap(err, "failed to ConnectTopic"))
 	}
 
-	if err := g.ConnectBridgeTopic("grav.reply"); err != nil {
+	if err := g.ConnectBridgeTopic("something.out"); err != nil {
 		log.Fatal(errors.Wrap(err, "failed to ConnectTopic"))
 	}
 
@@ -41,11 +41,11 @@ func main() {
 	go func() {
 		<-time.After(time.Second * time.Duration(5))
 		fmt.Println("sending 1")
-		pod.Send(grav.NewMsg(grav.MsgTypeDefault, []byte("world")))
+		pod.Send(grav.NewMsg("something.in", []byte("world")))
 
 		<-time.After(time.Second * time.Duration(5))
 		fmt.Println("sending 2")
-		pod.Send(grav.NewMsg(grav.MsgTypeDefault, []byte("again")))
+		pod.Send(grav.NewMsg("something.in", []byte("again")))
 	}()
 
 	<-time.After(time.Minute)

--- a/transport/kafka/transport.go
+++ b/transport/kafka/transport.go
@@ -111,8 +111,9 @@ func (c *Conn) Start(pod *grav.Pod) {
 
 				msg, err := grav.MsgFromBytes(record.Value)
 				if err != nil {
-					c.log.Error(errors.Wrap(err, "[bridge-kafka] failed to MsgFromBytes"))
-					continue
+					c.log.Debug(errors.Wrap(err, "[bridge-kafka] failed to MsgFromBytes, falling back to raw data").Error())
+
+					msg = grav.NewMsg(c.topic, record.Value)
 				}
 
 				// send to the Grav instance

--- a/transport/nats/transport.go
+++ b/transport/nats/transport.go
@@ -116,8 +116,9 @@ func (c *Conn) Start(pod *grav.Pod) {
 
 			msg, err := grav.MsgFromBytes(message.Data)
 			if err != nil {
-				c.log.Error(errors.Wrap(err, "[bridge-nats] failed to MsgFromBytes"))
-				continue
+				c.log.Debug(errors.Wrap(err, "[bridge-nats] failed to MsgFromBytes, falling back to raw data").Error())
+
+				msg = grav.NewMsg(c.topic, message.Data)
 			}
 
 			// send to the Grav instance

--- a/transport/websocket/transport.go
+++ b/transport/websocket/transport.go
@@ -16,6 +16,8 @@ import (
 	"github.com/suborbital/vektor/vlog"
 )
 
+const MsgTypeWebsocketMessage = "websocket.message"
+
 var upgrader = websocket.Upgrader{}
 
 // Transport is a transport that connects Grav nodes via standard websockets
@@ -185,8 +187,9 @@ func (c *Conn) Start(recvFunc grav.ReceiveFunc, signaler *grav.WithdrawSignaler)
 
 			msg, err := grav.MsgFromBytes(message)
 			if err != nil {
-				c.log.Error(errors.Wrap(err, "[transport-websocket] failed to MsgFromBytes"))
-				continue
+				c.log.Debug(errors.Wrap(err, "[transport-websocket] failed to MsgFromBytes, falling back to raw data").Error())
+
+				msg = grav.NewMsg(MsgTypeWebsocketMessage, message)
 			}
 
 			c.log.Debug("[transport-websocket] received message", msg.UUID(), "via", c.nodeUUID)


### PR DESCRIPTION
The transport plugins are (incorrectly) assuming that every message would be a JSON-encoded Grav message type. This PR gives them a fallback to use raw message data in the likely case the data has another shape.