### PR TITLE
fix(hub): add tunnel.Balancer and associated tests

### DIFF
--- a/grav/tunnel/balancer.go
+++ b/grav/tunnel/balancer.go
@@ -1,0 +1,71 @@
+package tunnel
+
+import "sync"
+
+// Balancer is a 'load balancer' for a list of UUIDs
+// each time 'Next' is called, a round-robin UUID from the list
+// is returned, the order is gobal and concurrency safe
+type Balancer struct {
+	uuids []string
+	index int
+	lock  sync.Mutex
+}
+
+// NewBalancer creates a new Balancer
+func NewBalancer() *Balancer {
+	b := &Balancer{
+		uuids: []string{},
+		index: 0,
+		lock:  sync.Mutex{},
+	}
+
+	return b
+}
+
+// Add adds a UUID to the list
+func (b *Balancer) Add(uuid string) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	b.uuids = append(b.uuids, uuid)
+}
+
+// Remove removes a UUID from the list if it exists
+// it re-creates the UUID list from scratch with a fresh array
+func (b *Balancer) Remove(uuid string) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	newUUIDs := []string{}
+
+	for i := range b.uuids {
+		if b.uuids[i] == uuid {
+			continue
+		}
+
+		newUUIDs = append(newUUIDs, b.uuids[i])
+	}
+
+	b.uuids = newUUIDs
+
+	// ensure the index isn't too large
+	if b.index >= len(b.uuids)-1 {
+		b.index = len(b.uuids) / 2
+	}
+}
+
+// Next returns the next round-robin UUID from the list
+func (b *Balancer) Next() string {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	uuid := b.uuids[b.index]
+
+	if b.index >= len(b.uuids)-1 {
+		b.index = 0
+	} else {
+		b.index++
+	}
+
+	return uuid
+}

--- a/grav/tunnel/balancer_test.go
+++ b/grav/tunnel/balancer_test.go
@@ -1,0 +1,56 @@
+package tunnel
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestBalancer(t *testing.T) {
+	balancer := NewBalancer()
+
+	balancer.Add("asdf")
+	balancer.Add("hjkl")
+	balancer.Add("qwer")
+
+	order := []string{"asdf", "hjkl", "qwer"}
+
+	for i := 0; i < 12; i++ {
+		next := balancer.Next()
+
+		shouldBe := order[i%3]
+
+		if next != shouldBe {
+			t.Error(fmt.Errorf("expected %s, got %s", shouldBe, next))
+		}
+	}
+
+	balancer.Add("uiop")
+	balancer.Add("zxcv")
+
+	order = append(order, "uiop", "zxcv")
+
+	for i := 0; i < 15; i++ {
+		next := balancer.Next()
+
+		shouldBe := order[i%5]
+
+		if next != shouldBe {
+			t.Error(fmt.Errorf("expected %s, got %s", shouldBe, next))
+		}
+	}
+
+	balancer.Remove("asdf")
+	balancer.Remove("hjkl")
+
+	order = order[2:]
+
+	for i := 0; i < 12; i++ {
+		next := balancer.Next()
+
+		shouldBe := order[i%3]
+
+		if next != shouldBe {
+			t.Error(fmt.Errorf("expected %s, got %s", shouldBe, next))
+		}
+	}
+}


### PR DESCRIPTION
We were using a MsgBuffer for client-side load balancing of Tunneled connections and it was horribly inefficient, plus a memory leak as the buffers would grow to a silly size over time.